### PR TITLE
ターゲット文字列読み込みの改行処理を明確化

### DIFF
--- a/app/script.py
+++ b/app/script.py
@@ -14,8 +14,11 @@ def load_config(config_file_path='/app/config.yaml'):
     return config
 
 def load_target_strings(target_strings_file_path, encoding, newline_char, debug_flag=False):
-    """ターゲット文字列をファイルから読み込む"""
-    with open(target_strings_file_path, 'r', encoding=encoding) as file:
+    """ターゲット文字列をファイルから読み込む
+
+    ファイルは ``newline=''`` を指定して開き、改行コードを変換しません。
+    """
+    with open(target_strings_file_path, 'r', encoding=encoding, newline='') as file:
         raw_target_strings = file.read()
     
     debug_log(f"Raw content read from file:\n{raw_target_strings}", debug_flag)


### PR DESCRIPTION
## 概要
- `load_target_strings` でファイルを開く際に `newline=''` を指定し、改行コードの変換を抑制
- 関数のドキュメントを更新して処理内容を明記

## テスト
- `bash run_tests.sh` を実行し、全6件のテストが成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_684186ff99d08321b8df7bb208ed0b7e