### PR TITLE
CSVフィルタを文字列比較に変更しテスト追加

### DIFF
--- a/app/script.py
+++ b/app/script.py
@@ -35,13 +35,20 @@ def load_target_strings(target_strings_file_path, encoding, newline_char, debug_
 def filter_csv(csv_file_path, encoding, column_index, header_flag, target_strings, debug_flag=False):
     """CSVファイルをロードして、指定した列にターゲット文字列が含まれる行をフィルタリングする"""
     # CSVファイルの読み込み
-    df = pd.read_csv(csv_file_path, encoding=encoding, header=0 if header_flag else None)
+    df = pd.read_csv(
+        csv_file_path,
+        encoding=encoding,
+        header=0 if header_flag else None,
+        dtype=str,
+    )
     
     debug_log(f"Dataframe head:\n{df.head()}", debug_flag)
     debug_log(f"Total rows: {len(df)}, Total columns: {len(df.columns)}", debug_flag)
     
-    # フィルタリング
-    filtered_df = df[df.iloc[:, column_index].astype(str).apply(lambda x: any(target in x for target in target_strings))]
+    # フィルタリング（文字列としての完全一致）
+    column_series = df.iloc[:, column_index].astype(str)
+    target_strings = [str(t) for t in target_strings]
+    filtered_df = df[column_series.isin(target_strings)]
     
     debug_log(f"Filtered dataframe head:\n{filtered_df.head()}", debug_flag)
     debug_log(f"Total matched rows: {len(filtered_df)}", debug_flag)

--- a/tests/fixtures/test_data.csv
+++ b/tests/fixtures/test_data.csv
@@ -1,6 +1,6 @@
 id,name,description
-1,apple,A red fruit
-2,banana,A yellow fruit
-3,orange,An orange fruit
-4,grape,A purple fruit
-5,cherry,A red fruit
+1,apple,red
+2,banana,yellow
+3,orange,orange
+4,grape,purple
+5,cherry,red

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -77,14 +77,14 @@ def test_load_target_strings():
 
 def test_filter_csv():
     """CSVフィルタリングが正しく動作するかテスト"""
-    # テスト用のターゲット文字列
+    # テスト用のターゲット文字列（完全一致）
     target_strings = ['red', 'orange']
     
     # フィルタリングを実行
     filtered_df = script.filter_csv(
         '/tmp/test_data.csv',
         'utf-8',
-        2,  # description列
+        2,  # description列（色名）
         True,  # ヘッダーあり
         target_strings,
         False  # デバッグフラグ
@@ -94,9 +94,27 @@ def test_filter_csv():
     assert len(filtered_df) == 3  # 'red'または'orange'を含む行は3行
     
     # 期待される結果をチェック
-    expected_ids = [1, 3, 5]  # apple, orange, cherryの行のID
+    expected_ids = ['1', '3', '5']  # apple, orange, cherryの行のID
     actual_ids = filtered_df['id'].tolist()
     assert sorted(actual_ids) == sorted(expected_ids)
+
+
+def test_filter_csv_string_equality():
+    """'01' と '1' が区別されるかテスト"""
+    csv_path = '/tmp/test_data_zero.csv'
+    with open(csv_path, 'w') as f:
+        f.write('id,name\n01,apple\n1,banana\n')
+
+    filtered_df = script.filter_csv(
+        csv_path,
+        'utf-8',
+        0,  # id列
+        True,
+        ['1'],
+        False,
+    )
+
+    assert filtered_df['id'].tolist() == ['1']
     
 
 def test_save_filtered_csv():


### PR DESCRIPTION
## 概要
CSV読み込み時にすべての列を文字列として扱った上で、フィルタ処理を文字列の完全一致で行うよう修正しました。また、`01` と `1` を区別できるか確認するテストを追加しました。

## 変更点
- `filter_csv` を `isin` を用いた文字列比較に変更
- フィクスチャ `test_data.csv` を色名のみの値に更新
- 新規テスト `test_filter_csv_string_equality` を追加

## テスト結果
`./run_tests.sh` を実行し、全 7 テストが成功することを確認しました。


------
https://chatgpt.com/codex/tasks/task_e_6853cb85769c8321b8af275ce93b1785